### PR TITLE
add frontegg oauth client code

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2023 Lokalise, Inc.
+Copyright 2024 Lokalise, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Minimalistic Frontegg OAuth implementation for browser applications. It offers A
 
 This package is an alternative to the official [Frontegg React SDK](https://github.com/frontegg/frontegg-react). 
 
-### Installation
+## Installation
 
 Use the package manager npm to install the library.
 
@@ -12,7 +12,7 @@ Use the package manager npm to install the library.
 npm install @lokalise/frontegg-oauth-client
 ```
 
-### Usage
+## Usage
 
 The library offers several APIs to initiate the OAuth flow and retrieve user data.
 
@@ -67,5 +67,13 @@ const handleRequest = async (request: Request) => {
     window.location.href = '/';
 }
 ```
+
+## Credits
+
+This library is brought to you by a joint effort of Lokalise engineers:
+
+[Arthur Suermondt](https://github.com/arthuracs)
+[Szymon Chudy](https://github.com/szymonchudy)
+[Ondrej Sevcik](https://github.com/ondrejsevcik)
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # frontegg-oauth-client
 
-Minimalistic Frontegg OAuth implementation for browser applications. It offers APIs for retrieving tokens and basic user data.
+Minimalistic Frontegg OAuth implementation for browser applications. It offers APIs for retrieving and refreshing tokens and basic user data.
 
 This package is an alternative to the official [Frontegg React SDK](https://github.com/frontegg/frontegg-react). 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Minimalistic Frontegg OAuth implementation for browser applications. It offers APIs for retrieving and refreshing tokens and basic user data.
 
-This package is an alternative to the official [Frontegg React SDK](https://github.com/frontegg/frontegg-react). 
+This package is an alternative to the official [@frontegg/js](https://docs.frontegg.com/docs/vanilla-js) package. 
 
 ## Installation
 
@@ -47,7 +47,7 @@ try {
 }
 ```
 
-You also need to setup OAuth callback path in your browser app.
+You also need to set up the OAuth callback path in your browser app. For that, we use the same client instance as in the code above.
 
 ```js
 // OAuth callback app - usually /oauth/callback URL

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# YourProjectName
+# FronteggOAuthClient
 
 ## Project Purpose
 
@@ -22,8 +22,8 @@ The following are all handled for you and do not need to be configured:
 ## Getting Started
 
 - [ ] Find and replace all instances of the symbols (case-insensitive) with your project name:
-  - `your-project-name`
-  - `YourProjectName`
+  - `frontegg-oauth-client`
+  - `FronteggOAuthClient`
 - [ ] Add an NPM token to GitHub secrets with the name `NPM_TOKEN`
   - This is required for publishing under the `@lokalise` NPM namespace.
 - [ ] Add a GitHub token to GitHub secrets with the name `GITHUB_TOKEN`

--- a/README.md
+++ b/README.md
@@ -1,90 +1,71 @@
-# FronteggOAuthClient
+# frontegg-oauth-client
 
-## Project Purpose
+Minimalistic Frontegg OAuth implementation for browser applications. It offers APIs for retrieving tokens and basic user data.
 
-This is a template repository, intended to accelerate teams at Lokalise to create public packages for publishing on NPM.
+This package is an alternative to the official [Frontegg React SDK](https://github.com/frontegg/frontegg-react). 
 
-This repository is not specifically frontend focused.
+### Installation
 
-## Key Features
+Use the package manager npm to install the library.
 
-The following are all handled for you and do not need to be configured:
-
-- Licensing
-- Linting
-- Formatting
-- Testing
-- Building
-- Bundling
-- Automated Versioning
-- Publishing
-
-## Getting Started
-
-- [ ] Find and replace all instances of the symbols (case-insensitive) with your project name:
-  - `frontegg-oauth-client`
-  - `FronteggOAuthClient`
-- [ ] Add an NPM token to GitHub secrets with the name `NPM_TOKEN`
-  - This is required for publishing under the `@lokalise` NPM namespace.
-- [ ] Add a GitHub token to GitHub secrets with the name `GITHUB_TOKEN`
-  - This is required to allow the automated semantic release process to push to `main`.
-- [ ] Update the `CODEOWNERS` file with your personal and/or team tags.
-
-Once you are all setup, we recommend reviewing and rewriting this README as necessary to make it more specific to your project.
-
-The last thing to do is actually start writing your code! We recommend starting from `src/index.ts` and `src/index.test.ts`.
-
-## Customizing the build
-
-The build system uses Vite. It is configured to treat `./src/index.ts` as the entry point of your repository. Feel free
-to change any particulars in `./vite.config.ts`. In particular if you require multiple entry points, we recommend
-reviewing Vite's documentation on this here: [Vite Library Mode](https://vitejs.dev/guide/build.html#library-mode).
-
-In case you add direct or peer dependencies, you should uncomment following lines (and corresponding import above) to
-ensure those dependencies are not directly included in the built package.
-
-```tsx
-external: Object.keys(packageJson.dependencies).flatMap((dep) => [
-	dep,
-	// Include all dependency paths, not just root
-	new RegExp(`^${dep}/`),
-])
+```bash
+npm install @lokalise/frontegg-oauth-client
 ```
 
-## commitlint
+### Usage
 
-You can use `npm run commit` to interactively construct correct commit messsage.
+The library offers several APIs to initiate the OAuth flow and retrieve user data.
 
-Check out [commitlint](https://commitlint.js.org) docs for examples of how to customise.
+```js
+// Create client instance
+const client = new FronteggOAuthClient({
+    baseUrl: 'https://frontegg-custom-url.com',
+    clientId: 'CLIENT_ID',
+    redirectUri: `${window.location.origin}/oauth/callback`,
+    logoutRedirectUri: window.location.origin,
+})
 
-## Release actions
+try {
+    // Retrieve user
+    const user = await client.getUserData();
 
-The following token needs to be set in the Github repo for the `prerelease` and `release` Github Actions to work:
+    // Retrieve token 
+    const accessToken = user.accessToken;
+} catch (error) {
+    // In case we receive a 401 Unauthorized error, we need to redirect the user to the login page.
+    if (error instanceof FronteggError && error.status === 401) {
+        // Retrieve login URL
+        const loginUrl = await client.getOAuthLoginUrl() 
+        
+        // Redirect to Frontegg login page
+        window.location.href = loginUrl;
+        return;
+    }
+    
+    // Rethrow unknown error.
+    throw error
+}
+```
 
-- `secrets.NPM_TOKEN` (need this to publish on NPM)
+You also need to setup OAuth callback path in your browser app.
 
-When performing a release, make sure to follow our conventional commit approach, as described in [contribution documentation](https://github.com/lokalise/npm-package-template/blob/main/CONTRIBUTING.md).
+```js
+// OAuth callback app - usually /oauth/callback URL
+const handleRequest = async (request: Request) => {
+    const oauthCode = new URL(request.url).searchParams.get('code')
 
-## License
+    if (!oauthCode) {
+        throw new Error('Missing oauth code');
+    }
 
-This project is APACHE, VERSION 2.0 licensed, see LICENSE.md for details.
+    // After successful login, the client can retrieve 
+    // the access token through the OAuth code.
+    await client.fetchAccessTokenByOAuthCode(oauthCode)
+    
+    
+    // Redirect the user to the main app
+    window.location.href = '/';
+}
+```
 
-## Template Specific Internal Notes
 
-The following notes are only relevant to the maintainers of this template. You may delete this section when you clone it.
-
-### Creating a release of the template
-
-- Merge your PR and create a [new draft release](https://github.com/lokalise/npm-package-template/releases/new).
-- Create a new tag `vx.x.x`. Consider the type of changes you added. Major, minor or patch.
-- In Release title mention the same version `vx.x.x`.
-- Generate release notes.
-- Publish Release
-
-## Other Resources
-
-This template represents the culmination of Lokalise technical recommendations as documented in the [Frontend Radar](https://lokalise.atlassian.net/l/cp/Bqkz2hC5).
-
-## Support Us
-
-**lokalise-npm-package-template** was created by Lokalise Engineering Team. Support our work by keeping this line in your README.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "@lokalise/frontegg-oauth-client",
       "version": "1.0.0",
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
       "devDependencies": {
         "@biomejs/biome": "^1.8.3",
         "@commitlint/cli": "^19.3.0",
@@ -19,6 +22,8 @@
         "@semantic-release/github": "^10.1.1",
         "@semantic-release/npm": "^12.0.1",
         "@semantic-release/release-notes-generator": "^14.0.1",
+        "jsdom": "^24.1.1",
+        "msw": "^2.3.2",
         "semantic-release": "^24.0.0",
         "typescript": "^5.5.4",
         "vite": "^5.3.4",
@@ -326,6 +331,26 @@
       ],
       "engines": {
         "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -1023,12 +1048,64 @@
         "node": ">=12"
       }
     },
+    "node_modules/@inquirer/confirm": {
+      "version": "3.1.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-3.1.17.tgz",
+      "integrity": "sha512-qCpt/AABzPynz8tr69VDvhcjwmzAryipWXtW8Vi6m651da4H/d0Bdn55LkxXD7Rp2gfgxvxzTdb66AhIA8gzBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.0.5",
+        "@inquirer/type": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.0.5.tgz",
+      "integrity": "sha512-QWG41I7vn62O9stYKg/juKXt1PEbr/4ZZCPb4KgXDQGwgA9M5NBTQ7FnOvT1ridbxkm/wTxLCNraUs7y47pIRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.5",
+        "@inquirer/type": "^1.5.1",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^20.14.11",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-spinners": "^2.9.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@inquirer/figures": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.5.tgz",
       "integrity": "sha512-79hP/VWdZ2UVc9bFGJnoQ/lQMpL74mGgzSYX1xUqCVk7/v73vJCMw1VuyWN1jGkZ9B3z7THAbySqGbCNefcjfA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.1.tgz",
+      "integrity": "sha512-m3YgGQlKNS0BM+8AFiJkCsTqHEFCWn6s/Rqye3mYwvqY6LdfUv12eSwbsgNzrYyrLXiy7IrrjDLPysaSBwEfhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -1231,6 +1308,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@mswjs/cookies": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.1.tgz",
+      "integrity": "sha512-W68qOHEjx1iD+4VjQudlx26CPIoxmIAtK4ZCexU0/UJBG6jYhcuyzKJx+Iw8uhBIGd9eba64XgWVgo20it1qwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.29.1.tgz",
+      "integrity": "sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.2.1",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1423,6 +1528,31 @@
       "dependencies": {
         "@octokit/openapi-types": "^22.2.0"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
@@ -2499,12 +2629,29 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.14.11",
@@ -2527,6 +2674,20 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.5.tgz",
+      "integrity": "sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -2865,6 +3026,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3284,6 +3452,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
@@ -3439,6 +3620,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3535,6 +3726,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
+      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dargs": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz",
@@ -3546,6 +3757,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/de-indent": {
@@ -3572,6 +3797,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3604,6 +3836,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/dir-glob": {
@@ -3972,6 +4214,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -4195,6 +4452,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -4250,6 +4517,13 @@
         "he": "bin/he"
       }
     },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
@@ -4284,6 +4558,19 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -4577,6 +4864,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4609,6 +4903,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "3.0.0",
@@ -4725,6 +5026,60 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.1.tgz",
+      "integrity": "sha512-5O1wWV99Jhq4DV7rCLIoZ/UIhyQeDR7wHVyZAHAshbrvZsLs+Xzz7gtwnlJTJDjleiTKh54F4dXrX70vJQTyJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -5138,6 +5493,29 @@
         "node": ">=16"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -5180,6 +5558,80 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/msw": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.3.2.tgz",
+      "integrity": "sha512-vDn6d6a50vxPE+HnaKQfpmZ4SVXlOjF97yD5FJcUT3v2/uZ65qvTYNL25yOmnrfCNWZ4wtAS7EbtXxygMug2Tw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@inquirer/confirm": "^3.0.0",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.29.0",
+        "@open-draft/until": "^2.1.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.2",
+        "path-to-regexp": "^6.2.0",
+        "strict-event-emitter": "^0.5.1",
+        "type-fest": "^4.9.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.23.0.tgz",
+      "integrity": "sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/muggle-string": {
       "version": "0.3.1",
@@ -7876,6 +8328,13 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.12.tgz",
+      "integrity": "sha512-qXDmcVlZV4XRtKFzddidpfVP4oMSGhga+xdMc25mv8kaLUHtgzCDhUxkrN8exkGdTlLNaXj7CV3GtON7zuGZ+w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7952,6 +8411,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-each-series": {
       "version": "3.0.0",
@@ -8160,6 +8626,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
+      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -8353,6 +8826,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8362,6 +8842,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -8538,6 +9025,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -8660,6 +9154,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-async": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
@@ -8717,6 +9218,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semantic-release": {
       "version": "24.0.0",
@@ -9244,6 +9758,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
@@ -9261,6 +9785,13 @@
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -9399,6 +9930,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/temp-dir": {
       "version": "3.0.0",
@@ -9575,6 +10113,45 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/traverse": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
@@ -9717,6 +10294,17 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -9948,6 +10536,19 @@
         "typescript": "*"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -9956,6 +10557,66 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -10012,6 +10673,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -10127,6 +10827,15 @@
       },
       "optionalDependencies": {
         "commander": "^9.4.1"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@lokalise/your-project-name",
+  "name": "@lokalise/frontegg-oauth-client",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@lokalise/your-project-name",
+      "name": "@lokalise/frontegg-oauth-client",
       "version": "1.0.0",
       "devDependencies": {
         "@biomejs/biome": "^1.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@commitlint/config-conventional": "^19.2.2",
         "@commitlint/prompt-cli": "^19.3.1",
         "@lokalise/biome-config": "^1.3.0",
+        "@lokalise/package-vite-config": "^3.0.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/git": "^10.0.1",
@@ -27,7 +28,6 @@
         "semantic-release": "^24.0.0",
         "typescript": "^5.5.4",
         "vite": "^5.3.4",
-        "vite-plugin-dts": "^3.9.1",
         "vitest": "^2.0.4"
       },
       "engines": {
@@ -1169,6 +1169,18 @@
       "integrity": "sha512-NH8dG7NJBZ24nYrpjzBi/bfinLYIDHX6LKrnTGOh6ErprLVxvt+TsiF+y/sj0XkCQgklt3cAJo7IlSiWmx5X4A==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@lokalise/package-vite-config": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@lokalise/package-vite-config/-/package-vite-config-3.0.0.tgz",
+      "integrity": "sha512-MRP4FpT9PDA8dgw1xLObpjErQ/o6zhlwJhUxXVeKEl55Yndlpn2sY2ZaLGzsOV0wkj+yBr0FoX7iBikC2cMW1Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "vite": "5.3.4",
+        "vite-plugin-dts": "3.9.1",
+        "vitest": "^2.0.3"
+      }
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.43.0",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,16 @@
     "test": "vitest run",
     "commit": "commit"
   },
-  "type": "module",
   "files": ["dist"],
-  "main": "./dist/frontegg-oauth-client.umd.cjs",
-  "module": "./dist/frontegg-oauth-client.js",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/frontegg-oauth-client.js",
-      "require": "./dist/frontegg-oauth-client.umd.cjs"
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
     }
   },
   "publishConfig": {
@@ -31,6 +33,7 @@
     "@commitlint/config-conventional": "^19.2.2",
     "@commitlint/prompt-cli": "^19.3.1",
     "@lokalise/biome-config": "^1.3.0",
+    "@lokalise/package-vite-config": "^3.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.0",
     "@semantic-release/git": "^10.0.1",
@@ -42,7 +45,6 @@
     "semantic-release": "^24.0.0",
     "typescript": "^5.5.4",
     "vite": "^5.3.4",
-    "vite-plugin-dts": "^3.9.1",
     "vitest": "^2.0.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@lokalise/your-project-name",
+  "name": "@lokalise/frontegg-oauth-client",
   "version": "1.0.0",
   "scripts": {
     "build": "vite build",
@@ -11,12 +11,12 @@
   },
   "type": "module",
   "files": ["dist"],
-  "main": "./dist/your-project-name.umd.cjs",
-  "module": "./dist/your-project-name.js",
+  "main": "./dist/frontegg-oauth-client.umd.cjs",
+  "module": "./dist/frontegg-oauth-client.js",
   "exports": {
     ".": {
-      "import": "./dist/your-project-name.js",
-      "require": "./dist/your-project-name.umd.cjs"
+      "import": "./dist/frontegg-oauth-client.js",
+      "require": "./dist/frontegg-oauth-client.umd.cjs"
     }
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@commitlint/cli": "^19.3.0",
@@ -34,6 +37,8 @@
     "@semantic-release/github": "^10.1.1",
     "@semantic-release/npm": "^12.0.1",
     "@semantic-release/release-notes-generator": "^14.0.1",
+    "jsdom": "^24.1.1",
+    "msw": "^2.3.2",
     "semantic-release": "^24.0.0",
     "typescript": "^5.5.4",
     "vite": "^5.3.4",

--- a/src/frontegg-oauth-client.test.ts
+++ b/src/frontegg-oauth-client.test.ts
@@ -1,0 +1,235 @@
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+import {
+  FronteggOAuthClient,
+  type GetFronteggTokenResponse,
+  type GetFronteggUserDataResponse,
+} from './frontegg-oauth-client'
+
+const EmptyResponse = (code: number) => new HttpResponse(null, { status: code })
+
+const baseUrl = 'http://frontegg-test-instance.local'
+const clientConfig = {
+  baseUrl,
+  clientId: 'test-client-id',
+  redirectUri: 'http://localhost:3000/oauth/callback',
+  logoutRedirectUri: 'http://localhost:3000',
+}
+
+const FRONTEGG_RESPONSE = {
+  token_type: 'Bearer',
+  access_token: 'test-access-token',
+  id_token: 'test-id-token',
+  refresh_token: 'test-refresh-token',
+  expires_in: 3600,
+} satisfies GetFronteggTokenResponse
+
+const FRONTEGG_USER_DATA = {
+  id: 'test-user-id',
+  email: 'test@lokalise.com',
+  name: 'dummy username',
+  profilePictureUrl: 'https://www.gravatar.com/avatar/00000000000000000000000000000000',
+  tenantId: 'test-tenant-id',
+} satisfies GetFronteggUserDataResponse
+
+const USER_DATA = {
+  externalUserId: FRONTEGG_USER_DATA.id,
+  accessToken: FRONTEGG_RESPONSE.access_token,
+  email: FRONTEGG_USER_DATA.email,
+  name: FRONTEGG_USER_DATA.name,
+  profilePictureUrl: FRONTEGG_USER_DATA.profilePictureUrl,
+  externalWorkspaceId: FRONTEGG_USER_DATA.tenantId,
+}
+
+const server = setupServer()
+server.listen()
+
+describe('frontegg-oauth-client', () => {
+  beforeEach(() => {
+    server.resetHandlers()
+  })
+
+  describe('userData', () => {
+    it('throws an error when unable to fetch user data', async () => {
+      server.use(
+        http.post(`${baseUrl}/frontegg/oauth/authorize/silent`, () => HttpResponse.error()),
+      )
+      const client = new FronteggOAuthClient(clientConfig)
+      await expect(() => client.getUserData()).rejects.toThrowError('Failed to fetch')
+    })
+
+    it('returns user data based on auth token', async () => {
+      server.use(
+        // This is a request that is made to the Frontegg API when the cookie is available
+        http.post(`${baseUrl}/frontegg/oauth/authorize/silent`, () =>
+          HttpResponse.json(FRONTEGG_RESPONSE),
+        ),
+        http.get(`${baseUrl}/frontegg/identity/resources/users/v2/me`, () =>
+          HttpResponse.json(FRONTEGG_USER_DATA),
+        ),
+      )
+
+      const client = new FronteggOAuthClient(clientConfig)
+      const userData = await client.getUserData()
+      expect(userData).toEqual(USER_DATA)
+      expect(client.userData).toEqual(USER_DATA)
+    })
+
+    it('allows to fetch user data only once at a time', async () => {
+      server.use(
+        http.post(`${baseUrl}/frontegg/oauth/authorize/silent`, () =>
+          HttpResponse.json(FRONTEGG_RESPONSE),
+        ),
+        http.get(`${baseUrl}/frontegg/identity/resources/users/v2/me`, () =>
+          HttpResponse.json(FRONTEGG_USER_DATA),
+        ),
+      )
+
+      const client = new FronteggOAuthClient(clientConfig)
+
+      const userDataPromise1 = client.getUserData()
+      const userDataPromise2 = client.getUserData()
+
+      // Check if both calls return the same promise
+      expect(userDataPromise1).toStrictEqual(userDataPromise2)
+
+      const userData = await userDataPromise1
+      const userData2 = await userDataPromise2
+
+      expect(userData).toEqual(USER_DATA)
+      expect(userData2).toEqual(USER_DATA)
+    })
+
+    it('returns user data based on refresh token', async () => {
+      server.use(
+        http.post(`${baseUrl}/frontegg/oauth/authorize/silent`, () =>
+          HttpResponse.json({ ...FRONTEGG_RESPONSE, expires_in: 0 }),
+        ),
+        http.get(`${baseUrl}/frontegg/identity/resources/users/v2/me`, () =>
+          HttpResponse.json(FRONTEGG_USER_DATA),
+        ),
+        http.post(`${baseUrl}/frontegg/oauth/token`, () =>
+          HttpResponse.json({
+            ...FRONTEGG_RESPONSE,
+            access_token: 'test-refreshed-access-token',
+          }),
+        ),
+      )
+
+      const client = new FronteggOAuthClient(clientConfig)
+
+      const userData = await client.getUserData()
+
+      expect(userData).toEqual(USER_DATA)
+      expect(client.userData).toEqual(USER_DATA)
+
+      const userDataRefreshed = await client.getUserData()
+
+      const expectedUserDataRefreshed = {
+        ...USER_DATA,
+        accessToken: 'test-refreshed-access-token',
+      }
+
+      expect(userDataRefreshed).toEqual(expectedUserDataRefreshed)
+      expect(client.userData).toEqual(expectedUserDataRefreshed)
+    })
+  })
+
+  describe('fetchAccessTokenByOAuthCode', () => {
+    it('throws an error when unable to fetch access token by OAuth code', async () => {
+      server.use(http.post(`${baseUrl}/frontegg/oauth/token`, () => HttpResponse.error()))
+      const client = new FronteggOAuthClient(clientConfig)
+      await expect(() =>
+        client.fetchAccessTokenByOAuthCode('test-oauth-code'),
+      ).rejects.toThrowError('Failed to fetch')
+    })
+
+    it('throws an error when api returns 401', async () => {
+      server.use(
+        http.post(`${baseUrl}/frontegg/oauth/token`, () =>
+          // Frontegg returns null and status 401 when the user is not authenticated
+          EmptyResponse(401),
+        ),
+      )
+
+      const client = new FronteggOAuthClient(clientConfig)
+      await expect(() =>
+        client.fetchAccessTokenByOAuthCode('test-oauth-code'),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[FronteggError: {"text":"Error while fetching Frontegg endpoint.","status":401,"url":"http://frontegg-test-instance.local/frontegg/oauth/token","fronteggTraceId":"undefined","body":"Error while fetching Frontegg endpoint."}]`,
+      )
+    })
+
+    it('returns access token based on OAuth code', async () => {
+      server.use(
+        http.post(`${baseUrl}/frontegg/oauth/token`, () => HttpResponse.json(FRONTEGG_RESPONSE)),
+      )
+
+      const client = new FronteggOAuthClient(clientConfig)
+      const accessToken = await client.fetchAccessTokenByOAuthCode('test-oauth-code')
+
+      expect(accessToken).toBe('test-access-token')
+    })
+  })
+
+  describe('fetchAccessTokenByOAuthRefreshToken', () => {
+    it('throws an error when unable to fetch access token by refresh token', async () => {
+      server.use(http.post(`${baseUrl}/frontegg/oauth/token`, () => HttpResponse.error()))
+      const client = new FronteggOAuthClient(clientConfig)
+      await expect(() =>
+        client.fetchAccessTokenByOAuthRefreshToken('test-oauth-code'),
+      ).rejects.toThrowError('Failed to fetch')
+    })
+
+    it('throws an error when api returns 401', async () => {
+      server.use(
+        http.post(`${baseUrl}/frontegg/oauth/token`, () =>
+          // Frontegg returns null and status 401 when the user is not authenticated
+          EmptyResponse(401),
+        ),
+      )
+
+      const client = new FronteggOAuthClient(clientConfig)
+      await expect(() =>
+        client.fetchAccessTokenByOAuthRefreshToken('test-oauth-code'),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[FronteggError: {"text":"Error while fetching Frontegg endpoint.","status":401,"url":"http://frontegg-test-instance.local/frontegg/oauth/token","fronteggTraceId":"undefined","body":"Error while fetching Frontegg endpoint."}]`,
+      )
+    })
+
+    it('returns access token based on refresh token', async () => {
+      server.use(
+        http.post(`${baseUrl}/frontegg/oauth/token`, () => HttpResponse.json(FRONTEGG_RESPONSE)),
+      )
+
+      const client = new FronteggOAuthClient(clientConfig)
+      const accessToken = await client.fetchAccessTokenByOAuthRefreshToken('test-oauth-code')
+
+      expect(accessToken).toBe('test-access-token')
+    })
+  })
+
+  describe('getOAuthLoginUrl', () => {
+    it('returns the OAuth login URL', async () => {
+      const client = new FronteggOAuthClient(clientConfig)
+      const loginUrl = await client.getOAuthLoginUrl()
+
+      expect(loginUrl.origin).toBe(baseUrl)
+      expect(loginUrl.searchParams.get('client_id')).toBe(clientConfig.clientId)
+      expect(loginUrl.searchParams.get('redirect_uri')).toBe(clientConfig.redirectUri)
+      expect(loginUrl.searchParams.get('scope')).toBe('openid profile email')
+    })
+  })
+
+  describe('getLogoutUrl', () => {
+    it('returns the logout URL', () => {
+      const client = new FronteggOAuthClient(clientConfig)
+      const loginUrl = client.getOAuthLogoutUrl()
+
+      expect(loginUrl.toString()).toBe(
+        'http://frontegg-test-instance.local/frontegg/oauth/logout?post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A3000',
+      )
+    })
+  })
+})

--- a/src/frontegg-oauth-client.ts
+++ b/src/frontegg-oauth-client.ts
@@ -1,0 +1,421 @@
+import { z } from 'zod'
+
+export interface FronteggUserData {
+  externalUserId: string
+  accessToken: string
+  name: string
+  email: string
+  profilePictureUrl: string | null | undefined
+  externalWorkspaceId: string
+}
+
+const GET_FRONTEGG_TOKEN_RESPONSE_SCHEMA = z.object({
+  token_type: z.string(),
+  access_token: z.string(),
+  id_token: z.string(),
+  refresh_token: z.string(),
+  expires_in: z.number(),
+})
+
+export type GetFronteggTokenResponse = z.infer<typeof GET_FRONTEGG_TOKEN_RESPONSE_SCHEMA>
+
+/**
+ * Frontegg specific error that contains extra fields for easier debugging.
+ */
+export class FronteggError extends Error {
+  text: string
+  status: number
+  url: string
+  // https://support.frontegg.com/hc/en-us/articles/7027392266525-How-do-I-find-the-frontegg-trace-id
+  fronteggTraceId: string
+  body: unknown
+
+  constructor(options: {
+    text: string
+    status: number
+    url: string
+    fronteggTraceId: string
+    body: unknown
+  }) {
+    super()
+    this.name = 'FronteggError'
+
+    this.text = options.text
+    this.status = options.status
+    this.url = options.url
+    this.fronteggTraceId = options.fronteggTraceId
+    this.body = options.body
+  }
+
+  override toString() {
+    return this.message
+  }
+
+  override get message(): string {
+    return JSON.stringify({
+      text: this.text,
+      status: this.status,
+      url: this.url,
+      fronteggTraceId: this.fronteggTraceId,
+      body: this.body,
+    })
+  }
+}
+
+/**
+ * Function to generate a random string
+ * From https://sentry.io/answers/generate-random-string-characters-in-javascript/
+ *
+ * @param length the length of the generated string
+ * @returns a random string
+ */
+const createRandomString = (length = 16) => {
+  let text = ''
+  const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  for (let i = 0; i < length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length))
+  }
+  return text
+}
+
+/**
+ * Function to generate a new code verifier string or retrieve it from the local storage
+ * Upon successful login on the hosted login page, we need to be able to reference the same `codeVerifier`
+ * when calling `getFronteggUserTokenByCode` so that Frontegg can check that the passed code matches
+ * the `codeVerifier` that was originally used to create the `code_challenge`.
+ *
+ * @returns a code verifier string
+ */
+const getCodeVerifier = async () => {
+  const localStorageVerifier = localStorage.getItem('LOGIN_VERIFIER_KEY')
+
+  if (localStorageVerifier) {
+    return localStorageVerifier
+  }
+
+  const verifier = createRandomString()
+  localStorage.setItem('LOGIN_VERIFIER_KEY', verifier)
+
+  // Safari has a bug, where the localStorage value is not set if it is followed by redirect right after it.
+  // To workaround this, we wait for a short period of time before returning the verifier.
+  // See https://lokalise.atlassian.net/browse/AP-4043 for more details.
+  await new Promise<void>((resolve) => {
+    setTimeout(() => {
+      resolve()
+    }, 200)
+  })
+
+  return verifier
+}
+
+/**
+ * Fetch function that throws an error if the response is not ok.
+ */
+const fetchWithAssert = async (url: string, options: RequestInit) => {
+  const response = await fetch(url, options)
+
+  if (!response.ok) {
+    const defaultMessage = 'Error while fetching Frontegg endpoint.'
+    const text = (await response.text().catch(() => defaultMessage)) || defaultMessage
+    const body: unknown = (await response.json().catch(() => defaultMessage)) || defaultMessage
+
+    throw new FronteggError({
+      text,
+      url,
+      fronteggTraceId: response.headers.get('frontegg-trace-id') ?? 'undefined',
+      status: response.status,
+      body,
+    })
+  }
+
+  return response
+}
+
+/**
+ * Function to calculate the expiration time of a token based on the number of seconds until it expires.
+ *
+ * @param expiresInSeconds the number of seconds until the token expires
+ * @returns the time in milliseconds since epoch when the token expires
+ */
+const calculateTokenExpirationTime = (expiresInSeconds: number) => {
+  return Date.now() + expiresInSeconds * 1000
+}
+
+/**
+ * Function to check if a token is expired based on its expiration time.
+ *
+ * @param tokenExpirationTime time in milliseconds since epoch when the token expires
+ * @returns boolean indicating whether the token is expired
+ */
+const isTokenExpired = (tokenExpirationTime: number | null) => {
+  if (!tokenExpirationTime) {
+    return true
+  }
+  // As a safety margin, we assume the token is expired 1 hour before the actual expiration time
+  return tokenExpirationTime - 60 * 60 * 1000 < Date.now()
+}
+
+const GET_FRONTEGG_USER_DATA_RESPONSE_SCHEMA = z.object({
+  id: z.string(),
+  email: z.string(),
+  name: z.string(),
+  profilePictureUrl: z.string().nullable().optional(),
+  tenantId: z.string(),
+})
+
+export type GetFronteggUserDataResponse = z.infer<typeof GET_FRONTEGG_USER_DATA_RESPONSE_SCHEMA>
+
+/**
+ * Class providing a Frontegg OAuth login with AccessToken and UserData.
+ * More information about native Frontegg authentication can be found at https://docs.frontegg.com/docs/native-hosted-login
+ */
+export class FronteggOAuthClient {
+  /**
+   * User data fetched from Frontegg.
+   */
+  public userData: FronteggUserData | null = null
+  /**
+   * Access token used to authenticate the user with Frontegg.
+   */
+  private accessToken: string | null = null
+  /**
+   * Refresh token used to get a new access token when the current one expires.
+   */
+  private refreshToken: string | null = null
+  /**
+   * Time in milliseconds since epoch when the token expires.
+   */
+  private tokenExpirationTime: number | null = null
+  /**
+   * Base URL of the Frontegg API
+   */
+  private readonly baseUrl: string
+  /**
+   * Client id from the Administration page of the Frontegg portal
+   */
+  private readonly clientId: string
+  /**
+   * The URL used to redirect the user after the OAuth login.
+   */
+  private readonly redirectUri: string
+  /**
+   * The URL used to redirect the user after the OAuth logout.
+   */
+  private readonly logoutRedirectUri: string
+  /**
+   * Cached promises to allow only one request at a time.
+   */
+  private userDataPromise: Promise<FronteggUserData> | null = null
+
+  constructor(config: {
+    baseUrl: string
+    clientId: string
+    redirectUri: string
+    logoutRedirectUri: string
+    userData?: FronteggUserData
+    refreshToken?: string
+    tokenExpirationTime?: number
+  }) {
+    this.baseUrl = config.baseUrl
+    this.clientId = config.clientId
+    this.redirectUri = config.redirectUri
+    this.logoutRedirectUri = config.logoutRedirectUri
+
+    if (config.userData) {
+      this.userData = config.userData
+      this.accessToken = config.userData.accessToken
+    }
+
+    if (config.refreshToken) this.refreshToken = config.refreshToken
+
+    if (config.tokenExpirationTime) this.tokenExpirationTime = config.tokenExpirationTime
+  }
+
+  /**
+   * Returns cached user data if it is already fetched.
+   * Otherwise, it tries to fetch fresh user data from Frontegg.
+   * In case the token is expired, the function throws an error.
+   *
+   * If there is a request is in progress, it returns the ongoing promise.
+   */
+  public async getUserData({ forceRefresh = false } = {}): Promise<FronteggUserData> {
+    if (this.userData && !isTokenExpired(this.tokenExpirationTime) && !forceRefresh) {
+      return this.userData
+    }
+
+    if (!this.userDataPromise) {
+      this.userDataPromise = this.getAccessToken({ forceRefresh })
+        .then((accessToken) => {
+          return this.fetchUserData(accessToken)
+        })
+        .then((userData) => {
+          this.userData = userData
+          this.userDataPromise = null
+          return this.userData
+        })
+        .catch((error: unknown) => {
+          this.userDataPromise = null
+          throw error
+        })
+    }
+
+    return this.userDataPromise
+  }
+
+  /**
+   * Function to get the Frontegg user access token.
+   * If the access token is already cached and not expired, it returns the cached token.
+   * If the access token is expired and a refresh token is available, it refreshes the access token and returns it.
+   * If the access token is not cached, it tries to fetch it from the cookie set by the Frontegg hosted login page.
+   *
+   * @returns a Frontegg user access token if the user is authenticated, otherwise throws an error.
+   */
+  private async getAccessToken({ forceRefresh = false } = {}): Promise<string> {
+    if (!this.accessToken) {
+      return await this.fetchAccessTokenByCookie()
+    }
+
+    if (this.refreshToken && (forceRefresh || isTokenExpired(this.tokenExpirationTime))) {
+      return await this.fetchAccessTokenByOAuthRefreshToken(this.refreshToken)
+    }
+
+    return this.accessToken
+  }
+
+  /**
+   * Function to get the Frontegg user access token from the cookie set by the Frontegg hosted login page.
+   *
+   * @returns a Frontegg user access token if the user is authenticated, otherwise throws an error.
+   */
+  private async fetchAccessTokenByCookie() {
+    const response = await fetchWithAssert(`${this.baseUrl}/frontegg/oauth/authorize/silent`, {
+      method: 'POST',
+      credentials: 'include',
+      // CORS is required as the Frontegg URL is on a different subdomain from the application
+      mode: 'cors',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const json: unknown = await response.json()
+    const data = GET_FRONTEGG_TOKEN_RESPONSE_SCHEMA.parse(json)
+    this.accessToken = data.access_token
+    this.refreshToken = data.refresh_token
+    this.tokenExpirationTime = calculateTokenExpirationTime(data.expires_in)
+    return this.accessToken
+  }
+
+  /**
+   * Function to exchange the OAuth code for a Frontegg user access token
+   *
+   * @returns a Frontegg user access token if the user is authenticated, otherwise throw an 401 FronteggError.
+   */
+  public async fetchAccessTokenByOAuthCode(oauthCode: string) {
+    const response = await fetchWithAssert(`${this.baseUrl}/frontegg/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        code: oauthCode,
+        redirect_uri: this.redirectUri,
+        code_verifier: await getCodeVerifier(),
+        grant_type: 'authorization_code',
+      }),
+    })
+
+    const json: unknown = await response.json()
+    const data = GET_FRONTEGG_TOKEN_RESPONSE_SCHEMA.parse(json)
+    this.accessToken = data.access_token
+    this.refreshToken = data.refresh_token
+    this.tokenExpirationTime = calculateTokenExpirationTime(data.expires_in)
+    return this.accessToken
+  }
+
+  /**
+   * Function to exchange the refresh token for a Frontegg user access token
+   *
+   * @returns a Frontegg user access token if the user is authenticated, otherwise throw an 401 FronteggError.
+   */
+  public async fetchAccessTokenByOAuthRefreshToken(refreshToken: string) {
+    const response = await fetchWithAssert(`${this.baseUrl}/frontegg/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        refresh_token: refreshToken,
+        grant_type: 'refresh_token',
+      }),
+    })
+
+    const json: unknown = await response.json()
+    const data = GET_FRONTEGG_TOKEN_RESPONSE_SCHEMA.parse(json)
+    this.accessToken = data.access_token
+    this.refreshToken = data.refresh_token
+    this.tokenExpirationTime = calculateTokenExpirationTime(data.expires_in)
+    return this.accessToken
+  }
+
+  /**
+   * Function to generate a valid Frontegg OAuth login URL
+   * Stores the code verifier variable in the local storage to be used when exchanging the OAuth code for a user access token
+   *
+   * @returns a Frontegg OAuth login URL to redirect the user to
+   * @see https://docs.frontegg.com/docs/native-hosted-login#step-2-request-auth-code
+   */
+  public async getOAuthLoginUrl() {
+    const codeVerifier = await getCodeVerifier()
+    const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier))
+    const hashedVerifier = btoa(String.fromCharCode(...new Uint8Array(digest)))
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+    const nonce = createRandomString()
+
+    const loginUrl = new URL(`${this.baseUrl}/frontegg/oauth/authorize`)
+    loginUrl.searchParams.set('client_id', this.clientId)
+    loginUrl.searchParams.set('redirect_uri', this.redirectUri)
+    loginUrl.searchParams.set('response_type', 'code')
+    loginUrl.searchParams.set('scope', 'openid profile email')
+    loginUrl.searchParams.set('code_challenge', hashedVerifier)
+    loginUrl.searchParams.set('code_challenge_method', 'S256')
+    loginUrl.searchParams.set('nonce', nonce)
+
+    return loginUrl
+  }
+
+  /**
+   * Returns URL for the Frontegg logout page.
+   * After the user is logged out, the function redirects the user to the provided URL.
+   */
+  public getOAuthLogoutUrl() {
+    const url = new URL(`${this.baseUrl}/frontegg/oauth/logout`)
+    url.searchParams.set('post_logout_redirect_uri', this.logoutRedirectUri)
+    return url.toString()
+  }
+
+  /**
+   * Function to fetch the user details from Frontegg.
+   * If the user is not authenticated or the access token is expired, the function throws error.
+   * More information: https://docs.frontegg.com/reference/userscontrollerv2_getuserprofile
+   */
+  private async fetchUserData(userAccessToken: string): Promise<FronteggUserData> {
+    const response = await fetchWithAssert(
+      `${this.baseUrl}/frontegg/identity/resources/users/v2/me`,
+      {
+        credentials: 'include',
+        headers: {
+          Authorization: `Bearer ${userAccessToken}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+
+    const data = GET_FRONTEGG_USER_DATA_RESPONSE_SCHEMA.parse(await response.json())
+
+    return {
+      externalUserId: data.id,
+      accessToken: userAccessToken,
+      email: data.email,
+      name: data.name,
+      profilePictureUrl: data.profilePictureUrl,
+      externalWorkspaceId: data.tenantId,
+    }
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,0 @@
-import { add } from './index'
-
-describe('add', () => {
-  it('can add two numbers', () => {
-    expect(add(1, 2)).toBe(3)
-  })
-})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,7 @@
-export const add = (a: number, b: number) => a + b
+export {
+  FronteggOAuthClient,
+  type FronteggUserData,
+  type FronteggError,
+  type GetFronteggTokenResponse,
+  type GetFronteggUserDataResponse,
+} from './frontegg-oauth-client'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,64 +1,12 @@
 import { resolve } from 'node:path'
-
-import dts from 'vite-plugin-dts'
-import { defineConfig } from 'vitest/config'
-
+import defineConfig from '@lokalise/package-vite-config/package'
 import packageJson from './package.json'
 
 // biome-ignore lint/style/noDefaultExport: Vite expects default export.
 export default defineConfig({
-  build: {
-    lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
-      name: 'FronteggOAuthClient',
-      fileName: 'frontegg-oauth-client',
-    },
-    rollupOptions: {
-      /**
-       * Uncomment these lines (and import above) if you add any direct or peer dependencies.
-       * This ensures they are not included directly in package but instead imported from node modules
-       */
-      external: Object.keys(packageJson.dependencies).flatMap((dep) => [
-        dep,
-        // Include all dependency paths, not just root
-        new RegExp(`^${dep}/`),
-      ]),
-      output: {
-        // Ensure we can tree-shake properly
-        preserveModules: true,
-        // Ensures import/require works in all environments
-        interop: 'auto',
-        // Must be `false` for `preserveModules: true`
-        inlineDynamicImports: false,
-      },
-
-      /**
-       * The Rollup building process does not break on some warning, this one ensures it returns
-       * correct exit status code so the GitHub Actions can break.
-       */
-      onwarn(warning) {
-        throw Object.assign(new Error(), warning)
-      },
-    },
-    commonjsOptions: {
-      // Assumes all external dependencies are ESM dependencies. Just ensures
-      // we then import those dependencies correctly in CJS as well.
-      esmExternals: true,
-    },
-  },
+  entry: resolve(__dirname, 'src/index.ts'),
+  dependencies: Object.keys(packageJson.dependencies),
   test: {
-    globals: true,
     environment: 'jsdom',
   },
-  plugins: [
-    dts({
-      afterDiagnostic: (diagnostics) => {
-        if (diagnostics.length > 0) {
-          throw new Error('Have issues with generating types', {
-            cause: diagnostics,
-          })
-        }
-      },
-    }),
-  ],
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    environment: 'jsdom',
   },
   plugins: [
     dts({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import dts from 'vite-plugin-dts'
 import { defineConfig } from 'vitest/config'
 
-import packageJson from "./package.json";
+import packageJson from './package.json'
 
 // biome-ignore lint/style/noDefaultExport: Vite expects default export.
 export default defineConfig({
@@ -19,9 +19,9 @@ export default defineConfig({
        * This ensures they are not included directly in package but instead imported from node modules
        */
       external: Object.keys(packageJson.dependencies).flatMap((dep) => [
-      	dep,
-      	// Include all dependency paths, not just root
-      	new RegExp(`^${dep}/`),
+        dep,
+        // Include all dependency paths, not just root
+        new RegExp(`^${dep}/`),
       ]),
       output: {
         // Ensure we can tree-shake properly

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,8 +10,8 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      name: 'YourProjectName',
-      fileName: 'your-project-name',
+      name: 'FronteggOAuthClient',
+      fileName: 'frontegg-oauth-client',
     },
     rollupOptions: {
       /**

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import dts from 'vite-plugin-dts'
 import { defineConfig } from 'vitest/config'
 
-// import packageJson from "./package.json";
+import packageJson from "./package.json";
 
 // biome-ignore lint/style/noDefaultExport: Vite expects default export.
 export default defineConfig({
@@ -18,11 +18,11 @@ export default defineConfig({
        * Uncomment these lines (and import above) if you add any direct or peer dependencies.
        * This ensures they are not included directly in package but instead imported from node modules
        */
-      // external: Object.keys(packageJson.dependencies).flatMap((dep) => [
-      // 	dep,
-      // 	// Include all dependency paths, not just root
-      // 	new RegExp(`^${dep}/`),
-      // ]),
+      external: Object.keys(packageJson.dependencies).flatMap((dep) => [
+      	dep,
+      	// Include all dependency paths, not just root
+      	new RegExp(`^${dep}/`),
+      ]),
       output: {
         // Ensure we can tree-shake properly
         preserveModules: true,


### PR DESCRIPTION
Adds frontegg oauth client code from Flow.

### Todo

- [x] Update Readme
- [x] Add an NPM token to GitHub secrets with the name `NPM_TOKEN` (This is required for publishing under the `@lokalise` NPM namespace.)
- [x] Add a GitHub token to GitHub secrets with the name `GITHUB_TOKEN` (This is required to allow the automated semantic release process to push to `main`.)
- [x] Notify Marcos for approval
