### PR TITLE
fix: export FrontenggError correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export {
+  FronteggError,
   FronteggOAuthClient,
   type FronteggUserData,
-  type FronteggError,
   type GetFronteggTokenResponse,
   type GetFronteggUserDataResponse,
 } from './frontegg-oauth-client'


### PR DESCRIPTION
The FronteggError was exported as a type and it was impossible to use it as a value. 