### PR TITLE
feat: throw a custom error when parsing the Frontegg response fails

### DIFF
--- a/src/frontegg-oauth-client.ts
+++ b/src/frontegg-oauth-client.ts
@@ -305,12 +305,19 @@ export class FronteggOAuthClient {
       this.tokenExpirationTime = calculateTokenExpirationTime(data.expires_in)
       return this.accessToken
     } catch (error: unknown) {
+      const includeResponseBody = !['access_token', 'id_token', 'refresh_token'].some((key) =>
+        JSON.stringify(json).includes(key),
+      )
+
       throw new FronteggError({
         text: 'Error while parsing Frontegg response.',
         status: 500,
         url: `${this.baseUrl}/frontegg/oauth/authorize/silent`,
         fronteggTraceId: response.headers.get('frontegg-trace-id') ?? 'undefined',
-        body: error,
+        body: {
+          response: includeResponseBody ? json : 'Response body contains sensitive information.',
+          error,
+        },
       })
     }
   }

--- a/src/frontegg-oauth-client.ts
+++ b/src/frontegg-oauth-client.ts
@@ -297,11 +297,22 @@ export class FronteggOAuthClient {
     })
 
     const json: unknown = await response.json()
-    const data = GET_FRONTEGG_TOKEN_RESPONSE_SCHEMA.parse(json)
-    this.accessToken = data.access_token
-    this.refreshToken = data.refresh_token
-    this.tokenExpirationTime = calculateTokenExpirationTime(data.expires_in)
-    return this.accessToken
+    try {
+      const data = GET_FRONTEGG_TOKEN_RESPONSE_SCHEMA.parse(json)
+
+      this.accessToken = data.access_token
+      this.refreshToken = data.refresh_token
+      this.tokenExpirationTime = calculateTokenExpirationTime(data.expires_in)
+      return this.accessToken
+    } catch (error: unknown) {
+      throw new FronteggError({
+        text: 'Error while parsing Frontegg response.',
+        status: 500,
+        url: `${this.baseUrl}/frontegg/oauth/authorize/silent`,
+        fronteggTraceId: response.headers.get('frontegg-trace-id') ?? 'undefined',
+        body: error,
+      })
+    }
   }
 
   /**

--- a/src/frontegg-oauth-client.ts
+++ b/src/frontegg-oauth-client.ts
@@ -305,17 +305,13 @@ export class FronteggOAuthClient {
       this.tokenExpirationTime = calculateTokenExpirationTime(data.expires_in)
       return this.accessToken
     } catch (error: unknown) {
-      const includeResponseBody = !['access_token', 'id_token', 'refresh_token'].some((key) =>
-        JSON.stringify(json).includes(key),
-      )
-
       throw new FronteggError({
         text: 'Error while parsing Frontegg response.',
         status: 500,
         url: `${this.baseUrl}/frontegg/oauth/authorize/silent`,
         fronteggTraceId: response.headers.get('frontegg-trace-id') ?? 'undefined',
         body: {
-          response: includeResponseBody ? json : 'Response body contains sensitive information.',
+          responseKeys: typeof json === 'object' && json !== null ? Object.keys(json) : undefined,
           error,
         },
       })


### PR DESCRIPTION
- Throws a custom FronteggError including the `frontegg-trace-id` when Zod parsing fails on `fetchAccessTokenByCookie`.
- Conditionally includes the original response body keys in the error if the response is an object