### PR TITLE
chore: Add PR Title Lint

### DIFF
--- a/.github/workflows/pr-lint-title.yml
+++ b/.github/workflows/pr-lint-title.yml
@@ -1,0 +1,23 @@
+# Action that makes sure the PR titles follow conventional commit
+# https://github.com/amannn/action-semantic-pull-request
+name: "Lint PR"
+
+on:
+    pull_request_target:
+        types:
+            - opened
+            - edited
+            - synchronize
+            - reopened
+
+permissions:
+    pull-requests: read
+
+jobs:
+    main:
+        name: Validate PR title
+        runs-on: ubuntu-latest
+        steps:
+            - uses: amannn/action-semantic-pull-request@v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint-title.yml
+++ b/.github/workflows/pr-lint-title.yml
@@ -1,6 +1,6 @@
 # Action that makes sure the PR titles follow conventional commit
 # https://github.com/amannn/action-semantic-pull-request
-name: "Lint PR"
+name: "Lint PR title"
 
 on:
     pull_request_target:


### PR DESCRIPTION
This will make sure that the PRs have to follow conventional commit convention. Same PR check as [we use in Louis](https://github.com/lokalise/louis/blob/main/.github/workflows/pr-lint-title.yml). 